### PR TITLE
Standardize build and publish scripts

### DIFF
--- a/CoreUpdaterPackage/publish.ps1
+++ b/CoreUpdaterPackage/publish.ps1
@@ -1,57 +1,42 @@
-# Define paths at top of script
-$scriptRoot = $PSScriptRoot ? $PSScriptRoot : (Get-Location).Path
-$moduleRoot = Join-Path $scriptRoot '..\Modules\OrchestratorCommon'
-$envConfigPath = Join-Path $scriptRoot '..\environments\dev.json'
+# publish.ps1
+# Publish script for CoreUpdaterPackage using the common Packaging module
 
-# Import the Az module to interact with Azure services
-# Import-Module Az
+$ArtifactsFeedName = "OrchestratorPshRepo"
+$SecretName = "PAT"
+$PackageName = "CoreUpdaterPackage"
 
-# Import OrchestratorCommon module
-if (Test-Path $moduleRoot) {
-    Import-Module $moduleRoot -Force
-    Write-Host "OrchestratorCommon module imported successfully." -ForegroundColor Green
-} else {
-    Write-Error "OrchestratorCommon module not found at $moduleRoot. Make sure the module is installed correctly."
+# --- Path Definitions ---
+$basePath = ($PSScriptRoot ? $PSScriptRoot : (Get-Location).Path)
+$envConfigPath = Join-Path $basePath '..\environments\dev.json'
+$commonModuleRootPath = Join-Path $basePath '..\Modules\OrchestratorCommon'
+$packagingModulePath = Join-Path $basePath '..\Modules\Packaging\Packaging.psd1'
+$nuspecFilePath = Join-Path $basePath 'CoreUpdaterPackage.nuspec'
+$outputDirectory = Join-Path $basePath '..\Output'
+
+# --- Module Imports & Initialization ---
+try {
+    if (Test-Path $commonModuleRootPath) { Import-Module $commonModuleRootPath -Force }
+    Import-Module $packagingModulePath
+    Initialize-12Configuration $envConfigPath
+} catch {
+    Write-Error "Failed during module import or initialization: $($_.Exception.Message)"
     exit 1
 }
 
-# Define variables
-if (Test-Path $envConfigPath) {
-    $envConfig = Get-Content -Path $envConfigPath -Raw | ConvertFrom-Json
-    $KeyVaultName = $envConfig.keyVaultName
-    $TenantId = $envConfig.tenantId
-    $SubscriptionId = $envConfig.subscriptionId
-    $ArtifactsFeedUrl = $envConfig.artifactsFeedUrl
-    Write-Host "Using Key Vault: $KeyVaultName from environments/dev.json" -ForegroundColor Cyan
-    Write-Host "Using Tenant ID: $TenantId from environments/dev.json" -ForegroundColor Cyan
-    Write-Host "Using Subscription ID: $SubscriptionId from environments/dev.json" -ForegroundColor Cyan
-    Write-Host "Using Artifacts Feed URL: $ArtifactsFeedUrl from environments/dev.json" -ForegroundColor Cyan
-} else {
-    Write-Error "Could not find environment config at $envConfigPath. Aborting package publishing."
+# --- Main Script Execution ---
+try {
+    $packageVersion = Get-PackageVersionFromNuspec -NuspecPath $nuspecFilePath
+    $nupkgFilePath = Join-Path -Path $outputDirectory -ChildPath "$PackageName.$packageVersion.nupkg"
+    Write-Host "Full package path: $nupkgFilePath" -ForegroundColor Cyan
+    if (-not (Test-Path $nupkgFilePath)) { throw "Package file not found: $nupkgFilePath" }
+
+    $pat = Get-NuGetPATFromKeyVault -SecretName $SecretName
+    $artifactsFeedUrl = $Global:12cConfig.artifactsFeedUrl
+    if ([string]::IsNullOrEmpty($artifactsFeedUrl)) { throw "Missing ArtifactsFeedUrl from global scope." }
+    Ensure-NuGetFeedConfigured -FeedName $ArtifactsFeedName -FeedUrl $artifactsFeedUrl -PAT $pat
+
+    Publish-NuGetPackageAndCleanup -PackagePath $nupkgFilePath -FeedName $ArtifactsFeedName
+} catch {
+    Write-Error "An error occurred during script execution: $($_.Exception.Message)"
     exit 1
 }
-
-$SecretName = "PAT"   # Replace with the name of the secret storing the PAT
-
-# Detect the latest package in the correct output directory
-$outputDirectory = Join-Path $scriptRoot '..' 'Output'
-$packageFiles = Get-ChildItem -Path $outputDirectory -Filter 'CoreUpdaterPackage.*.nupkg' | Sort-Object Name -Descending
-if ($packageFiles) {
-    $PackagePath = $packageFiles[0].FullName
-    Write-Host "Using latest package: $PackagePath" -ForegroundColor Cyan
-} else {
-    Write-Error "No CoreUpdaterPackage nupkg files found in $outputDirectory."
-    exit 1
-}
-
-# Retrieve the PAT securely
-$PersonalAccessToken = Get-PATFromKeyVault -KeyVaultName $KeyVaultName -SecretName $SecretName -TenantId $TenantId -SubscriptionId $SubscriptionId
-
-# Set up the NuGet source with the PAT
-nuget.exe sources add -Name "ArtifactsFeed" -Source $ArtifactsFeedUrl -Username "AzureDevOps" -Password $PersonalAccessToken -StorePasswordInClearText
-
-# Publish the package
-nuget.exe push $PackagePath -Source "ArtifactsFeed" -ApiKey "AzureDevOps"
-
-# Clean up the NuGet source to remove sensitive information
-nuget.exe sources remove -Name "ArtifactsFeed"

--- a/Modules/CosmosDB/publish.ps1
+++ b/Modules/CosmosDB/publish.ps1
@@ -1,84 +1,52 @@
 # publish.ps1
-# Script to publish the CosmosDB module NuGet package
+# Script to publish the CosmosDB module using the common Packaging module
 
-# Define paths at top of script
-$scriptRoot = $PSScriptRoot ? $PSScriptRoot : (Get-Location).Path
-$configModulePath = Join-Path $scriptRoot '..\..\Modules\Configuration\ConfigurationPackage\ConfigurationPackage.psd1'
-$orchestratorAzureModulePath = Join-Path $scriptRoot '..\..\Modules\OrchestratorAzure\OrchestratorAzure.psd1'
-$envConfigPath = Join-Path $scriptRoot '..\..\environments\dev.json'
-$orchestratorCommonModulePath = Join-Path $scriptRoot '..\..\Modules\OrchestratorCommon'
-$packagePath = Join-Path $scriptRoot 'CosmosDBPackage.nuspec'
-$outputDirectory = Join-Path $scriptRoot '..\..\Output'
+$ArtifactsFeedName = "OrchestratorPshRepo"
+$SecretName = "PAT"
+$PackageName = "CosmosDBPackage"
 
-# Set the NuGet source name
-$ArtifactsFeed = "OrchestratorPshRepo"
-$SecretName = "PAT"   # Replace with the name of the secret storing the PAT
+# --- Path Definitions ---
+$basePath = ($PSScriptRoot ? $PSScriptRoot : (Get-Location).Path)
+$envConfigPath = Join-Path $basePath "..\..\environments\dev.json"
+$configModulePsd1 = Join-Path $basePath "..\Configuration\ConfigurationPackage\ConfigurationPackage.psd1"
+$azureModulePsd1 = Join-Path $basePath "..\OrchestratorAzure\OrchestratorAzure.psd1"
+$commonModuleRootPath = Join-Path $basePath "..\OrchestratorCommon"
+$packagingModulePath = Join-Path $basePath "..\Packaging\Packaging.psd1"
+$nuspecFilePath = Join-Path $basePath "CosmosDBPackage.nuspec"
+$outputDirectory = Join-Path $basePath "..\..\Output"
 
-Import-Module $configModulePath
-Import-Module $orchestratorAzureModulePath
-Initialize-12Configuration $envConfigPath
-Connect-12Azure
+# --- Module Imports & Initialization ---
+try {
+    Import-Module $configModulePsd1
+    Import-Module $azureModulePsd1
+    Import-Module $packagingModulePath
+    Initialize-12Configuration $envConfigPath
+    Connect-12Azure
 
-# Import OrchestratorCommon module
-if (Test-Path $orchestratorCommonModulePath) {
-    Import-Module $orchestratorCommonModulePath -Force
-    Write-Host "OrchestratorCommon module imported successfully." -ForegroundColor Green
-} else {
-    Write-Error "OrchestratorCommon module not found at $orchestratorCommonModulePath. Make sure the module is installed correctly."
+    if (Test-Path $commonModuleRootPath) {
+        Import-Module $commonModuleRootPath -Force
+    }
+} catch {
+    Write-Error "Failed during module import or initialization: $($_.Exception.Message)"
     exit 1
 }
 
-# Define variables
-if (Test-Path $envConfigPath) {
-    $envConfig = Get-Content -Path $envConfigPath -Raw | ConvertFrom-Json
-    $KeyVaultName = $envConfig.keyVaultName
-    $TenantId = $envConfig.tenantId
-    $SubscriptionId = $envConfig.subscriptionId
-    $ArtifactsFeedUrl = $envConfig.artifactsFeedUrl
-    Write-Host "Using Key Vault: $KeyVaultName from environments/dev.json`nUsing Tenant ID: $TenantId from environments/dev.json`nUsing Subscription ID: $SubscriptionId from environments/dev.json`nUsing Artifacts Feed URL: $ArtifactsFeedUrl from environments/dev.json" -ForegroundColor Cyan
-} else {
-    Write-Error "Could not find environment config at $envConfigPath. Aborting package publishing."
+# --- Main Script Execution ---
+try {
+    $packageVersion = Get-PackageVersionFromNuspec -NuspecPath $nuspecFilePath
+    $nupkgFilePath = Join-Path -Path $outputDirectory -ChildPath "$PackageName.$packageVersion.nupkg"
+    Write-Host "Full package path: $nupkgFilePath" -ForegroundColor Cyan
+    if (-not (Test-Path $nupkgFilePath)) { throw "Package file not found: $nupkgFilePath" }
+
+    $pat = Get-NuGetPATFromKeyVault -SecretName $SecretName
+    $artifactsFeedUrl = $Global:12cConfig.artifactsFeedUrl
+    if ([string]::IsNullOrEmpty($artifactsFeedUrl)) { throw "Missing ArtifactsFeedUrl from global scope." }
+    Ensure-NuGetFeedConfigured -FeedName $ArtifactsFeedName -FeedUrl $artifactsFeedUrl -PAT $pat
+
+    Publish-NuGetPackageAndCleanup -PackagePath $nupkgFilePath -FeedName $ArtifactsFeedName
+
+    Write-Host "Script completed successfully." -ForegroundColor Green
+} catch {
+    Write-Error "An error occurred during script execution: $($_.Exception.Message)"
     exit 1
 }
-
-# Get the package version from the nuspec file
-$nuspecContent = Get-Content $packagePath -Raw
-if ($nuspecContent -match '<version>([0-9]+)\.([0-9]+)\.([0-9]+)</version>') {
-    $major = $matches[1]
-    $minor = $matches[2]
-    $patch = $matches[3]
-    $version = "$major.$minor.$patch"
-    Write-Host "Package version from nuspec: $version" -ForegroundColor Cyan
-} else {
-    Write-Error "Failed to find version in nuspec file."
-    exit 1
-}
-
-# Detect the latest package in the output directory
-$PackagePath = Join-Path $outputDirectory "CosmosDBPackage.$version.nupkg"
-Write-Host "Using package path: $PackagePath" -ForegroundColor Cyan
-
-# Verify the package exists
-if (-not (Test-Path $PackagePath)) {
-    Write-Error "Package not found at $PackagePath. Please build the package first."
-    exit 1
-}
-
-Write-Host "Publishing package $PackagePath..." -ForegroundColor Cyan
-
-# Retrieve the PAT securely
-$PersonalAccessToken = Get-PATFromKeyVault -KeyVaultName $KeyVaultName -SecretName $SecretName -TenantId $TenantId -SubscriptionId $SubscriptionId
-
-# Set up the NuGet source with the PAT
-Write-Host "Adding NuGet source..." -ForegroundColor Cyan
-nuget sources add -Name $ArtifactsFeed -Source $ArtifactsFeedUrl -Username "AzureDevOps" -Password $PersonalAccessToken -StorePasswordInClearText
-
-# Publish the package
-Write-Host "Pushing package to feed..." -ForegroundColor Cyan
-nuget push $PackagePath -Source $ArtifactsFeed -ApiKey "AzureDevOps"
-
-# Clean up the NuGet source to remove sensitive information
-Write-Host "Cleaning up..." -ForegroundColor Cyan
-nuget sources remove -Name $ArtifactsFeed
-
-Write-Host "Package published successfully!" -ForegroundColor Green

--- a/Modules/MessagingModule/publish.ps1
+++ b/Modules/MessagingModule/publish.ps1
@@ -1,90 +1,52 @@
 # publish.ps1
-# Script to publish the messaging package to a NuGet feed
+# Script to publish the MessagingModule package using the common Packaging module
 
-# Todo:
-# If artifacts feed already exists it fails. 
+$ArtifactsFeedName = "OrchestratorPshRepo"
+$SecretName = "PAT"
+$PackageName = "MessagingModule"
 
-# Define paths at top of script
-$scriptRoot = $PSScriptRoot ? $PSScriptRoot : (Get-Location).Path
-$configModulePath = Join-Path $scriptRoot '..\..\Modules\Configuration\ConfigurationPackage\ConfigurationPackage.psd1'
-$orchestratorAzureModulePath = Join-Path $scriptRoot '..\..\Modules\OrchestratorAzure\OrchestratorAzure.psd1'
-$envConfigPath = Join-Path $scriptRoot '..\..\environments\dev.json'
-$orchestratorCommonModulePath = Join-Path $scriptRoot '..\..\Modules\OrchestratorCommon'
-$packagePath = Join-Path $scriptRoot 'MessagingModule.nuspec'
-$outputDirectory = Join-Path $scriptRoot '..\..\Output'
+# --- Path Definitions ---
+$basePath = ($PSScriptRoot ? $PSScriptRoot : (Get-Location).Path)
+$envConfigPath = Join-Path $basePath "..\..\environments\dev.json"
+$configModulePsd1 = Join-Path $basePath "..\Configuration\ConfigurationPackage\ConfigurationPackage.psd1"
+$azureModulePsd1 = Join-Path $basePath "..\OrchestratorAzure\OrchestratorAzure.psd1"
+$commonModuleRootPath = Join-Path $basePath "..\OrchestratorCommon"
+$packagingModulePath = Join-Path $basePath "..\Packaging\Packaging.psd1"
+$nuspecFilePath = Join-Path $basePath "MessagingModule.nuspec"
+$outputDirectory = Join-Path $basePath "..\..\Output"
 
-# Import the Az module to interact with Azure services
-# Import-Module Az
+# --- Module Imports & Initialization ---
+try {
+    Import-Module $configModulePsd1
+    Import-Module $azureModulePsd1
+    Import-Module $packagingModulePath
+    Initialize-12Configuration $envConfigPath
+    Connect-12Azure
 
-# Set the NuGet source name
-$ArtifactsFeed = "OrchestratorPshRepo"
-$SecretName = "PAT"   # Replace with the name of the secret storing the PAT
-
-Import-Module $configModulePath
-Import-Module $orchestratorAzureModulePath
-Initialize-12Configuration $envConfigPath
-Connect-12Azure
-
-# Import OrchestratorCommon module
-if (Test-Path $orchestratorCommonModulePath) {
-    Import-Module $orchestratorCommonModulePath -Force
-    Write-Host "OrchestratorCommon module imported successfully." -ForegroundColor Green
-} else {
-    Write-Error "OrchestratorCommon module not found at $orchestratorCommonModulePath. Make sure the module is installed correctly."
+    if (Test-Path $commonModuleRootPath) {
+        Import-Module $commonModuleRootPath -Force
+    }
+} catch {
+    Write-Error "Failed during module import or initialization: $($_.Exception.Message)"
     exit 1
 }
 
-# Define variables
-if (Test-Path $envConfigPath) {
-    $envConfig = Get-Content -Path $envConfigPath -Raw | ConvertFrom-Json
-    $KeyVaultName = $envConfig.keyVaultName
-    $TenantId = $envConfig.tenantId
-    $SubscriptionId = $envConfig.subscriptionId
-    $ArtifactsFeedUrl = $envConfig.artifactsFeedUrl
-    Write-Host "Using Key Vault: $KeyVaultName from environments/dev.json`nUsing Tenant ID: $TenantId from environments/dev.json`nUsing Subscription ID: $SubscriptionId from environments/dev.json`nUsing Artifacts Feed URL: $ArtifactsFeedUrl from environments/dev.json" -ForegroundColor Cyan
-} else {
-    Write-Error "Could not find environment config at $envConfigPath. Aborting package publishing."
+# --- Main Script Execution ---
+try {
+    $packageVersion = Get-PackageVersionFromNuspec -NuspecPath $nuspecFilePath
+    $nupkgFilePath = Join-Path -Path $outputDirectory -ChildPath "$PackageName.$packageVersion.nupkg"
+    Write-Host "Full package path: $nupkgFilePath" -ForegroundColor Cyan
+    if (-not (Test-Path $nupkgFilePath)) { throw "Package file not found: $nupkgFilePath" }
+
+    $pat = Get-NuGetPATFromKeyVault -SecretName $SecretName
+    $artifactsFeedUrl = $Global:12cConfig.artifactsFeedUrl
+    if ([string]::IsNullOrEmpty($artifactsFeedUrl)) { throw "Missing ArtifactsFeedUrl from global scope." }
+    Ensure-NuGetFeedConfigured -FeedName $ArtifactsFeedName -FeedUrl $artifactsFeedUrl -PAT $pat
+
+    Publish-NuGetPackageAndCleanup -PackagePath $nupkgFilePath -FeedName $ArtifactsFeedName
+
+    Write-Host "Script completed successfully." -ForegroundColor Green
+} catch {
+    Write-Error "An error occurred during script execution: $($_.Exception.Message)"
     exit 1
 }
-
-# Get the package version from the nuspec file
-$nuspecContent = Get-Content $packagePath -Raw
-if ($nuspecContent -match '<version>([0-9]+)\.([0-9]+)\.([0-9]+)</version>') {
-    $major = $matches[1]
-    $minor = $matches[2]
-    $patch = $matches[3]
-    $version = "$major.$minor.$patch"
-    Write-Host "Package version from nuspec: $version" -ForegroundColor Cyan
-} else {
-    Write-Error "Failed to find version in nuspec file."
-    exit 1
-}
-
-# Detect the latest package in the output directory
-$PackagePath = Join-Path $outputDirectory "MessagingModule.$version.nupkg"
-Write-Host "Using package path: $PackagePath" -ForegroundColor Cyan
-
-# Verify the package exists
-if (-not (Test-Path $PackagePath)) {
-    Write-Error "Package not found at $PackagePath. Please build the package first."
-    exit 1
-}
-
-Write-Host "Publishing package $PackagePath..." -ForegroundColor Cyan
-
-# Retrieve the PAT securely
-$PersonalAccessToken = Get-PATFromKeyVault -KeyVaultName $KeyVaultName -SecretName $SecretName -TenantId $TenantId -SubscriptionId $SubscriptionId
-
-# Set up the NuGet source with the PAT
-Write-Host "Adding NuGet source..." -ForegroundColor Cyan
-nuget sources add -Name $ArtifactsFeed -Source $ArtifactsFeedUrl -Username "AzureDevOps" -Password $PersonalAccessToken -StorePasswordInClearText
-
-# Publish the package
-Write-Host "Pushing package to feed..." -ForegroundColor Cyan
-nuget push $PackagePath -Source $ArtifactsFeed -ApiKey "AzureDevOps"
-
-# Clean up the NuGet source to remove sensitive information
-Write-Host "Cleaning up..." -ForegroundColor Cyan
-nuget sources remove -Name $ArtifactsFeed
-
-Write-Host "Package published successfully!" -ForegroundColor Green


### PR DESCRIPTION
## Summary
- reuse Packaging module in MessagingModule, CosmosDB, and CoreUpdaterPackage build/publish scripts

## Testing
- `pwsh -NoLogo -NoProfile -Command Get-Command pwsh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844bbbbb5888332963eed06fdf77c62